### PR TITLE
Fix for #9 and #12. New feature: apply gift for each subset of products, multiple gifts per rule

### DIFF
--- a/Observer/RemoveGiftItems.php
+++ b/Observer/RemoveGiftItems.php
@@ -34,7 +34,7 @@ class RemoveGiftItems implements ObserverInterface
     /**
      * Delete all gift items. They will be re-added by SalesRule (If possible).
      *
-     * @event sales_quote_address_collect_totals_before
+     * @event sales_quote_remove_item
      * @param Observer $observer
      * @return void
      */

--- a/Observer/ResetGiftItems.php
+++ b/Observer/ResetGiftItems.php
@@ -2,6 +2,7 @@
 
 namespace C4B\FreeProduct\Observer;
 
+use C4B\Freeproduct\SalesRule\Action\ForeachGiftAction;
 use C4B\FreeProduct\SalesRule\Action\GiftAction;
 
 use Magento\Framework\Event\Observer;
@@ -107,6 +108,7 @@ class ResetGiftItems implements ObserverInterface
                 }
             } else
             {
+                $quoteItem->unsetData(ForeachGiftAction::APPLIED_FREEPRODUCT_RULE_IDS);
                 $realQuoteItems[$key] = $quoteItem;
             }
         }

--- a/Observer/ResetGiftItems.php
+++ b/Observer/ResetGiftItems.php
@@ -2,7 +2,7 @@
 
 namespace C4B\FreeProduct\Observer;
 
-use C4B\Freeproduct\SalesRule\Action\ForeachGiftAction;
+use C4B\FreeProduct\SalesRule\Action\ForeachGiftAction;
 use C4B\FreeProduct\SalesRule\Action\GiftAction;
 
 use Magento\Framework\Event\Observer;

--- a/Observer/ResetGiftItems.php
+++ b/Observer/ResetGiftItems.php
@@ -57,7 +57,13 @@ class ResetGiftItems implements ObserverInterface
 
         if ($shippingAssignment instanceof ShippingAssignmentInterface)
         {
+            /** @var Quote\Address $address */
             $address = $shippingAssignment->getShipping()->getAddress();
+
+            if ($address->getAddressType() != Quote\Address::ADDRESS_TYPE_SHIPPING)
+            {
+                return;
+            }
         }
         else
         {

--- a/Plugin/SalesRule/Model/MetadataValueProvider.php
+++ b/Plugin/SalesRule/Model/MetadataValueProvider.php
@@ -3,6 +3,8 @@
 namespace C4B\FreeProduct\Plugin\SalesRule\Model;
 
 use C4B\FreeProduct\SalesRule\Action\GiftAction;
+use C4B\FreeProduct\SalesRule\Action\ForeachGiftAction;
+
 use \Magento\SalesRule\Model\Rule\Metadata\ValueProvider as Source;
 
 /**
@@ -27,6 +29,9 @@ class MetadataValueProvider
     {
         $resultMetadataValues['actions']['children']['simple_action']['arguments']['data']['config']['options'][] = [
             'label' => __('Add a Gift'), 'value' =>  GiftAction::ACTION
+        ];
+        $resultMetadataValues['actions']['children']['simple_action']['arguments']['data']['config']['options'][] = [
+            'label' => __('Add a Gift (For each cart item)'), 'value' =>  ForeachGiftAction::ACTION
         ];
 
         return $resultMetadataValues;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The development and the function of the original Magento1 extension is described
 
 Requirements
 -------
-- PHP >= 7.0.0
+- PHP >= 7.1
 - Magento >= 2.2
 
 Supported Product Types
@@ -35,8 +35,13 @@ Configuration
 -------
 Sales rules for carts are configured in _Marketing->Cart Price Rules_:  
 - In the Actions tab, the Apply field should be set to Add a Gift
-- Gift SKU: Product that will be added. Only simple and virtual products without (required) custom options are supported
-- Discount Amount: The qty of added gifts
+- Gift SKU: Product that will be added. Only simple and virtual products without (required) custom options are supported. Multiple comma-separated SKUs can be specified
+- Discount Amount: The qty of added gifts  
+- The gift item is added once for the whole cart
+
+Action **Add a Gift (for each cart item)** works similarly but will add the gift item for each product in cart. The qty of said product is also taken into consideration.  
+
+This action usually needs conditions to match only specific items *(Apply the rule only to cart items matching the following conditions)*.   
 
 Limitations:
 -------

--- a/SalesRule/Action/ForeachGiftAction.php
+++ b/SalesRule/Action/ForeachGiftAction.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace C4B\FreeProduct\SalesRule\Action;
+
+use C4B\FreeProduct\Observer\ResetGiftItems;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Customer\Model\Address;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
+use Magento\SalesRule\Model\Rule\Action\Discount;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Adds a gift for each cart item that meets criteria. It is also multiplied by the qty of said cart item.
+ * Ex. Add one gift for each product from category Sales.
+ *
+ * @package    C4B_FreeProduct
+ * @author     Dominik Meglič <meglic@code4business.de>
+ * @copyright  code4business Software GmbH
+ * @license    http://opensource.org/licenses/osl-3.0.php
+ */
+class ForeachGiftAction extends GiftAction
+{
+    const ACTION = 'add_gift_foreach';
+    /**
+     * @var ResetGiftItems
+     */
+    private $resetGiftItems;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+
+    /**
+     * @param Discount\DataFactory $discountDataFactory
+     * @param ProductRepositoryInterface $productRepository
+     * @param ResetGiftItems $resetGiftItems
+     * @param LoggerInterface $logger
+     */
+    public function __construct(Discount\DataFactory $discountDataFactory,
+                                ProductRepositoryInterface $productRepository,
+                                ResetGiftItems $resetGiftItems,
+                                LoggerInterface $logger)
+    {
+        parent::__construct($discountDataFactory, $productRepository, $logger);
+        $this->resetGiftItems = $resetGiftItems;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param \Magento\SalesRule\Model\Rule $rule
+     * @param AbstractItem $item
+     * @param float $qty
+     * @return Discount\Data
+     */
+    public function calculate($rule, $item, $qty)
+    {
+        $appliedRuleIds = $item->getData(static::APPLIED_FREEPRODUCT_RULE_IDS);
+
+        if ($item->getAddress()->getAddressType() != Address::TYPE_SHIPPING
+            || ($appliedRuleIds != null && isset($appliedRuleIds[$rule->getId()])))
+        {
+            return $this->getDiscountData($item);
+        }
+
+        $skus = explode(',', $rule->getData(static::RULE_DATA_KEY_SKU));
+        $isRuleAdded = false;
+
+        foreach ($skus as $sku)
+        {
+            try
+            {
+                $quoteItem = $item->getQuote()->addProduct($this->getGiftProduct($sku), $rule->getDiscountAmount() * $qty);
+                $item->getQuote()->setItemsCount($item->getQuote()->getItemsCount() + 1);
+                $item->getQuote()->setItemsQty((float)$item->getQuote()->getItemsQty() + $quoteItem->getQty());
+                $this->resetGiftItems->reportGiftItemAdded();
+
+                if (is_string($quoteItem))
+                {
+                    throw new \Exception($quoteItem);
+                }
+
+                $isRuleAdded = true;
+            } catch (\Exception $e)
+            {
+                $this->logger->error(
+                    sprintf('Exception occurred while adding gift product %s to cart. Rule: %d, Exception: %s', implode(',', $skus), $rule->getId(), $e->getMessage()),
+                    [__METHOD__]
+                );
+                }
+            }
+        if ($isRuleAdded)
+        {
+            $this->addAppliedRuleIdToItem($rule->getRuleId(), $item);
+        }
+
+        return $this->getDiscountData($item);
+    }
+
+    /**
+     * @param int $ruleId
+     * @param AbstractItem $quoteItem
+     */
+    protected function addAppliedRuleIdToItem(int $ruleId, AbstractItem $quoteItem)
+    {
+        $appliedRules = $quoteItem->getData(static::APPLIED_FREEPRODUCT_RULE_IDS);
+
+        if ($appliedRules == null)
+        {
+            $appliedRules = [];
+        }
+
+        $appliedRules[$ruleId] = $ruleId;
+
+        $quoteItem->setData(static::APPLIED_FREEPRODUCT_RULE_IDS, $appliedRules);
+    }
+}

--- a/SalesRule/Action/ForeachGiftAction.php
+++ b/SalesRule/Action/ForeachGiftAction.php
@@ -42,7 +42,7 @@ class ForeachGiftAction extends GiftAction
                                 ResetGiftItems $resetGiftItems,
                                 LoggerInterface $logger)
     {
-        parent::__construct($discountDataFactory, $productRepository, $logger);
+        parent::__construct($discountDataFactory, $productRepository, $resetGiftItems, $logger);
         $this->resetGiftItems = $resetGiftItems;
         $this->logger = $logger;
     }
@@ -87,8 +87,8 @@ class ForeachGiftAction extends GiftAction
                     sprintf('Exception occurred while adding gift product %s to cart. Rule: %d, Exception: %s', implode(',', $skus), $rule->getId(), $e->getMessage()),
                     [__METHOD__]
                 );
-                }
             }
+        }
         if ($isRuleAdded)
         {
             $this->addAppliedRuleIdToItem($rule->getRuleId(), $item);

--- a/SalesRule/Action/GiftAction.php
+++ b/SalesRule/Action/GiftAction.php
@@ -88,26 +88,26 @@ class GiftAction implements Discount\DiscountInterface
 
         foreach ($skus as $sku)
         {
-        try
-        {
-            $quoteItem = $item->getQuote()->addProduct($this->getGiftProduct($sku), $rule->getDiscountAmount());
-            $item->getQuote()->setItemsCount($item->getQuote()->getItemsCount() + 1);
-            $item->getQuote()->setItemsQty((float)$item->getQuote()->getItemsQty() + $quoteItem->getQty());
-            $this->resetGiftItems->reportGiftItemAdded();
-
-            if (is_string($quoteItem))
+            try
             {
-                throw new \Exception($quoteItem);
-            }
+                $quoteItem = $item->getQuote()->addProduct($this->getGiftProduct($sku), $rule->getDiscountAmount());
+                $item->getQuote()->setItemsCount($item->getQuote()->getItemsCount() + 1);
+                $item->getQuote()->setItemsQty((float)$item->getQuote()->getItemsQty() + $quoteItem->getQty());
+                $this->resetGiftItems->reportGiftItemAdded();
+
+                if (is_string($quoteItem))
+                {
+                    throw new \Exception($quoteItem);
+                }
 
                 $isRuleAdded = true;
-        } catch (\Exception $e)
-        {
-            $this->logger->error(
+            } catch (\Exception $e)
+            {
+                $this->logger->error(
                     sprintf('Exception occurred while adding gift product %s to cart. Rule: %d, Exception: %s', implode(',', $skus), $rule->getId(), $e->getMessage()),
-                [__METHOD__]
-            );
-        }
+                    [__METHOD__]
+                );
+            }
         }
 
         if ($isRuleAdded)

--- a/SalesRule/Action/GiftAction.php
+++ b/SalesRule/Action/GiftAction.php
@@ -83,8 +83,11 @@ class GiftAction implements Discount\DiscountInterface
             return $this->getDiscountData($item);
         }
 
-        $sku = $rule->getData(static::RULE_DATA_KEY_SKU);
+        $skus = explode(',', $rule->getData(static::RULE_DATA_KEY_SKU));
+        $isRuleAdded = false;
 
+        foreach ($skus as $sku)
+        {
         try
         {
             $quoteItem = $item->getQuote()->addProduct($this->getGiftProduct($sku), $rule->getDiscountAmount());
@@ -97,13 +100,19 @@ class GiftAction implements Discount\DiscountInterface
                 throw new \Exception($quoteItem);
             }
 
-            $this->addAppliedRuleId($rule->getRuleId(), $item->getAddress());
+                $isRuleAdded = true;
         } catch (\Exception $e)
         {
             $this->logger->error(
-                sprintf('Exception occurred while adding gift product %s to cart. Rule: %d, Exception: %s', $sku, $rule->getId(), $e->getMessage()),
+                    sprintf('Exception occurred while adding gift product %s to cart. Rule: %d, Exception: %s', implode(',', $skus), $rule->getId(), $e->getMessage()),
                 [__METHOD__]
             );
+        }
+        }
+
+        if ($isRuleAdded)
+        {
+            $this->addAppliedRuleId($rule->getRuleId(), $item->getAddress());
         }
 
         return $this->getDiscountData($item);

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "phpunit/phpunit": "~6.2.0"
   },
   "type": "magento2-module",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "phpunit/phpunit": "~6.2.0"
   },
   "type": "magento2-module",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "phpunit/phpunit": "~6.2.0"
   },
   "type": "magento2-module",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/code4business/freeproduct2",
   "require": {
     "magento/module-sales-rule": ">=100.0.0",
-    "php": ">=7.0"
+    "php": ">=7.1"
   },
   "require-dev": {
     "tddwizard/magento2-fixtures": "^0.1.0",

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\SalesRule\Model\Rule\Metadata\ValueProvider">
-        <plugin name="freeproduct" type="C4B\FreeProduct\Plugin\SalesRule\Model\MetadataValueProvider" sortOrder="10" />
+        <plugin name="FreeProduct" type="C4B\FreeProduct\Plugin\SalesRule\Model\MetadataValueProvider" sortOrder="10" />
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4,6 +4,7 @@
         <arguments>
             <argument name="discountRules" xsi:type="array">
                 <item name="add_gift" xsi:type="string">C4B\FreeProduct\SalesRule\Action\GiftAction</item>
+                <item name="add_gift_foreach" xsi:type="string">C4B\FreeProduct\SalesRule\Action\ForeachGiftAction</item>
             </argument>
         </arguments>
     </type>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="sales_quote_collect_totals_before">
-        <observer name="Freeproduct" instance="C4B\Freeproduct\Observer\ResetGiftItems" />
+        <observer name="FreeProduct" instance="C4B\FreeProduct\Observer\ResetGiftItems" />
     </event>
 
     <event name="sales_quote_address_collect_totals_before">
-        <observer name="Freeproduct" instance="C4B\FreeProduct\Observer\ResetGiftItems" />
+        <observer name="FreeProduct" instance="C4B\FreeProduct\Observer\ResetGiftItems" />
     </event>
 
     <event name="sales_quote_remove_item">

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="sales_quote_collect_totals_before">
+        <observer name="Freeproduct" instance="C4B\Freeproduct\Observer\ResetGiftItems" />
+    </event>
+
     <event name="sales_quote_address_collect_totals_before">
         <observer name="Freeproduct" instance="C4B\FreeProduct\Observer\ResetGiftItems" />
     </event>
+
     <event name="sales_quote_remove_item">
         <observer name="FreeproductOnQuoteDelete" instance="C4B\FreeProduct\Observer\RemoveGiftItems" />
     </event>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,3 +1,4 @@
 "Add a Gift","Add a Gift"
+"Add a Gift (For each cart item)","Add a Gift (For each cart item)"
 "Gift SKU","Gift SKU"
 "Only simple and virtual types are supported.","Only simple and virtual types are supported."

--- a/i18n/sl_SI.csv
+++ b/i18n/sl_SI.csv
@@ -1,3 +1,4 @@
 "Add a Gift","Dodaj darilo"
+"Add a Gift (For each cart item)","Dodaj darilo (Za vsak artikel v košarici)"
 "Gift SKU","SKU darila"
 "Only simple and virtual types are supported.","Podprta sta samo enostavni in virtualni tip artikla."


### PR DESCRIPTION
Fixes #9 and #12.
New features:
- Allow multiple gifts in one rule. Comma separated SKUs
- New action: Add gift for each cart item. Example: Add one pen for each product from category "Office Equipment".