### PR TITLE
Error on Delete Items via API

### DIFF
--- a/Observer/RemoveGiftItems.php
+++ b/Observer/RemoveGiftItems.php
@@ -44,7 +44,7 @@ class RemoveGiftItems implements ObserverInterface
         $quote = $this->checkoutSession->getQuote();
 
         /** @var Quote\Item $quoteItem */
-        if ($quote && count($quote->getItems())) {
+        if ($quote && (is_array($quote->getItems()) || is_object($quote->getItems())) && count($quote->getItems())) {
             foreach ($quote->getItems() as $quoteItem) {
                 if ($quoteItem->getOptionByCode(GiftAction::ITEM_OPTION_UNIQUE_ID) instanceof Quote\Item\Option) {
                     $quoteItem->isDeleted(true);


### PR DESCRIPTION
Due to lack of input type verification, when attempting to delete an item from the cart by the API route /carts/mine/items/:itemId the plugin generates an error "The item could not be removed from the quote.", this resolve.