### PR TITLE
Fix #21 Set Original Price when ordering

### DIFF
--- a/Plugin/Model/Quote/Item/AbstractItem.php
+++ b/Plugin/Model/Quote/Item/AbstractItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace C4B\FreeProduct\Plugin\Model\Quote\Item;
+
+use C4B\FreeProduct\SalesRule\Action\GiftAction;
+
+/**
+ * In rare cases (for example when the order runs through an ERP) is is nice to have the original_price
+ * of a free gift item available.
+ *
+ * Also allows to see the original price in the backend and is good for statistics.
+ *
+ * That is why we set it here.
+ *
+ * @package C4B\FreeProduct\Plugin\Model\Quote\Item
+ */
+class AbstractItem
+{
+    public function aroundGetOriginalPrice(\Magento\Quote\Model\Quote\Item\AbstractItem $subject, callable $proceed)
+    {
+        if ($subject->getProductType() == GiftAction::PRODUCT_TYPE_FREEPRODUCT) {
+            return $subject->getProduct()->getPrice();
+        }
+
+        return $proceed();
+    }
+}

--- a/Test/Integration/FreeProductTest.php
+++ b/Test/Integration/FreeProductTest.php
@@ -88,6 +88,7 @@ class FreeProductTest extends TestCase
 
         $this->assertTrue($freeproductItem !== null, 'Quote does not contain Freeproduct item');
         $this->assertEquals(0, $freeproductItem->getPrice(), 'Price is not zero');
+        $this->assertEquals(50, $freeproductItem->getOriginalPrice(), 'Custom Price is not preserved');
         $this->assertEquals(2, $freeproductItem->getQty(), 'Incorrect gift count was added.');
     }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -30,4 +30,7 @@
     <type name="Klarna\Core\Api\BuilderInterface">
         <plugin sortOrder="10" name="freeproduct_save_quote_after_klarna_totals_recollect" type="C4B\FreeProduct\Plugin\KlarnaPayments\Api\Builder" />
     </type>
+    <type name="Magento\Quote\Model\Quote\Item\AbstractItem">
+        <plugin sortOrder="1" name="freeproduct_add_original_price" type="C4B\FreeProduct\Plugin\Model\Quote\Item\AbstractItem"/>
+    </type>
 </config>


### PR DESCRIPTION
The original price is not in the quote but set to 0 because of
the free-product logic. This fixes that and sets an
original_price, which is later available in the
sales_order_item.original_price field