### PR TITLE
Only set items in admin context.

### DIFF
--- a/Observer/ResetGiftItems.php
+++ b/Observer/ResetGiftItems.php
@@ -37,6 +37,16 @@ class ResetGiftItems implements ObserverInterface
     private $areGiftItemsReset = false;
 
     /**
+     * @var bool
+     */
+    private $isAdminContext = false;
+
+    public function __construct(bool $isAdminContext = false)
+    {
+        $this->isAdminContext = $isAdminContext;
+    }
+
+    /**
      * @event sales_quote_collect_totals_before
      * @event sales_quote_address_collect_totals_before
      * @param Observer $observer
@@ -51,8 +61,10 @@ class ResetGiftItems implements ObserverInterface
         $shippingAssignment = $observer->getEvent()->getData('shipping_assignment');
 
         // In admin the quote items are empty although items exist
-        if ((int)$quote->getItemsCount() > 0 && $quote->getItems() == null) {
-            $quote->setItems($quote->getItemsCollection()->getItems());
+        if ($this->isAdminContext) {
+            if ((int)$quote->getItemsCount() > 0 && $quote->getItems() == null) {
+                $quote->setItems($quote->getItemsCollection()->getItems());
+            }
         }
 
         if ($quote->getItems() == null || $this->areGiftItemsReset)

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -3,4 +3,10 @@
     <type name="Magento\SalesRule\Model\Rule\Metadata\ValueProvider">
         <plugin name="FreeProduct" type="C4B\FreeProduct\Plugin\SalesRule\Model\MetadataValueProvider" sortOrder="10" />
     </type>
+
+    <type name="C4B\FreeProduct\Observer\ResetGiftItems">
+        <arguments>
+            <argument name="isAdminContext" xsi:type="boolean">true</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Quote has strange behavior where it might duplicate items if they are set in the quotes setItems, instead of in the item collection.
When creating an order in admin this isn't the case, instead a different bug appears where quote items is empty but items collection is not.

This will ensure the bugfix for the admin problem is only applied in the admin context.

Fixes #38